### PR TITLE
Implement c4::fs::EntryList::iterator_impl<>::operator[]

### DIFF
--- a/src/c4/fs/fs.hpp
+++ b/src/c4/fs/fs.hpp
@@ -394,6 +394,7 @@ private:
         iterator_impl& operator+= (size_t adv) { i += adv; return *this; }
         iterator_impl& operator-= (size_t adv) { i -= adv; return *this; }
         ssize_t operator- (iterator_impl that) const { C4_ASSERT(that.entry_list == entry_list); C4_CHECK(i >= that.i); return ssize_t(i) - ssize_t(that.i); }
+        reference operator[] (size_t adv) const { return *(this->operator+(adv)); }
     };
 
 public:


### PR DESCRIPTION
Fixes #5 by using the existing methods to implement the missing method.